### PR TITLE
Add `$GITHUB_WORKSPACE` as a safe directory

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -51,6 +51,7 @@ babel --version
 echo -e "\n${BOLD}Setting up Git${PLAIN}"
 git config --global user.name "${GITHUB_ACTOR}"
 git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 echo "machine github.com login ${GITHUB_ACTOR} password ${INPUT_GITHUBTOKEN}" > ~/.netrc
 
 git clone --depth=1 --single-branch --branch "${INPUT_BRANCH}" "https://x-access-token:${INPUT_GITHUBTOKEN}@github.com/${REPO}.git" /tmp/gh-pages


### PR DESCRIPTION
In the context of a GitHub action, mark `$GITHUB_WORKSPACE` as a safe
directory.

Related:
- https://github.blog/2022-04-12-git-security-vulnerability-announced/
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765