### PR TITLE
Add destinationDir input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     required: false
     default: 'gh-pages'
   
+  destinationDir:
+    description: 'The directory to push the built site to'
+    required: false
+
   repo:
     description: 'The repo to push the built site to'
     required: false

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,6 +27,12 @@ else
   REPO=${GITHUB_REPOSITORY}
 fi
 
+if [ "${INPUT_DESTINATIONDIR}" ]; then
+  PUBLISH_DIRECTORY="${CLONE_DIRECTORY}/${INPUT_DESTINATIONDIR}"
+else
+  PUBLISH_DIRECTORY="${CLONE_DIRECTORY}"
+fi
+
 CD=${INPUT_SITEDIR:=$(pwd)}
 
 [ -z "${INPUT_GITHUBTOKEN}" ] && \
@@ -55,13 +61,13 @@ git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 echo "machine github.com login ${GITHUB_ACTOR} password ${INPUT_GITHUBTOKEN}" > ~/.netrc
 
 git clone --depth=1 --single-branch --branch "${INPUT_BRANCH}" "https://x-access-token:${INPUT_GITHUBTOKEN}@github.com/${REPO}.git" $CLONE_DIRECTORY
-rm -rf "${CLONE_DIRECTORY}/*"
+rm -rf "${PUBLISH_DIRECTORY}/*"
 
 
 echo -e "\n${BOLD}Generating Site ${NAME} at commit ${GITHUB_SHA}${PLAIN}"
 cd ${CD}
 hugo mod get
-hugo ${INPUT_ARGS} -d "${CLONE_DIRECTORY}/"
+hugo ${INPUT_ARGS} -d "${PUBLISH_DIRECTORY}"
 
 
 echo -e "\n${BOLD}Commiting${PLAIN}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 PLAIN='\033[0m'
 BOLD='\033[1;37m'
-
+CLONE_DIRECTORY="/tmp/gh-pages"
 
 if [ "${INPUT_HUGOVERSION}" ]; then
   echo -e "\n${BOLD}Using Hugo version ${INPUT_HUGOVERSION}.${PLAIN}"
@@ -54,18 +54,18 @@ git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 echo "machine github.com login ${GITHUB_ACTOR} password ${INPUT_GITHUBTOKEN}" > ~/.netrc
 
-git clone --depth=1 --single-branch --branch "${INPUT_BRANCH}" "https://x-access-token:${INPUT_GITHUBTOKEN}@github.com/${REPO}.git" /tmp/gh-pages
-rm -rf /tmp/gh-pages/*
+git clone --depth=1 --single-branch --branch "${INPUT_BRANCH}" "https://x-access-token:${INPUT_GITHUBTOKEN}@github.com/${REPO}.git" $CLONE_DIRECTORY
+rm -rf "${CLONE_DIRECTORY}/*"
 
 
 echo -e "\n${BOLD}Generating Site ${NAME} at commit ${GITHUB_SHA}${PLAIN}"
 cd ${CD}
 hugo mod get
-hugo ${INPUT_ARGS} -d /tmp/gh-pages/
+hugo ${INPUT_ARGS} -d "${CLONE_DIRECTORY}/"
 
 
 echo -e "\n${BOLD}Commiting${PLAIN}"
-cd /tmp/gh-pages
+cd $CLONE_DIRECTORY
 
 [ -n "${INPUT_CNAME}" ] && \
   echo "${INPUT_CNAME}" > CNAME


### PR DESCRIPTION
 Add destinationDir input
    
If the destination directory is different than the root folder this
input can be used to indicate it which will make the action to only modify
the contents within that folder

If destinationdir is set to hugo, then docker-entrypoint.sh will:

1. Delete only the contents of hugo/*
2. Build the new site to hugo/
3. Push the result.

This is useful if the publishing branch is used to publish more than one
site, for example:

example.org/docs (hugo based)
example.org/blog (jekyll based)